### PR TITLE
Fixed sharing wasn't working when it is on iPad (closes #83)

### DIFF
--- a/lib/pages/fullscreen_view_page.dart
+++ b/lib/pages/fullscreen_view_page.dart
@@ -90,12 +90,12 @@ class _FullScreenViewPageState extends State<FullScreenViewPage> {
   Widget _shareButton(StableHordeTask task) {
     if (!task.isComplete()) return const SizedBox.shrink();
 
-    return IconButton(
-      icon: Icon(Icons.adaptive.share),
-      onPressed: () async {
-        final outputFile = await imageTranscodeBloc.transcodeImageToJpg(task);
-
-        await Share.shareXFiles([XFile(outputFile.path)]);
+    return Builder(
+      builder: (BuildContext context) {
+        return IconButton(
+          icon: Icon(Icons.adaptive.share),
+          onPressed: () => _onShare(context, task),
+        );
       },
     );
   }
@@ -200,6 +200,16 @@ class _FullScreenViewPageState extends State<FullScreenViewPage> {
         BlendMode.modulate,
       ),
       child: child,
+    );
+  }
+
+  void _onShare(BuildContext context, StableHordeTask task) async {
+    final RenderBox box = context.findRenderObject() as RenderBox;
+    final outputFile = await imageTranscodeBloc.transcodeImageToJpg(task);
+
+    await Share.shareXFiles(
+      [XFile(outputFile.path)],
+      sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
     );
   }
 }


### PR DESCRIPTION
## Context

Sharing was not working when user is on iPad. The root cause is because we didn't set mandatory parameter when sharing on iPad ([link](https://pub.dev/packages/share_plus))

Closes #83 

### From the official documentation

<img width="450" alt="Screenshot 2023-01-29 at 6 22 31 PM" src="https://user-images.githubusercontent.com/5780664/215374238-a0e1da88-2481-47e7-bc47-10b57f1eb9eb.png">

### Solution

Added `sharePositionOrigin` parameter when sharing X file.

## Testing

Verified new changes on following devices:

- Google pixel 2xl (Android - device)
- Google pixel 5 (Android - simulator)
- iPhone 14 Pro (iOS - simulator)
- iPad 10th gen (iOS - device)