### PR TITLE
Added null check before using RenderBox

### DIFF
--- a/lib/pages/fullscreen_view_page.dart
+++ b/lib/pages/fullscreen_view_page.dart
@@ -255,12 +255,16 @@ class _FullScreenViewPageState extends State<FullScreenViewPage> {
   }
 
   void _onShare(BuildContext context, StableHordeTask task) async {
-    final RenderBox box = context.findRenderObject() as RenderBox;
+    final RenderBox? box = context.findRenderObject() as RenderBox?;
     final outputFile = await imageTranscodeBloc.transcodeImageToJpg(task);
 
-    await Share.shareXFiles(
-      [XFile(outputFile.path)],
-      sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
-    );
+    if (box == null) {
+      await Share.shareXFiles([XFile(outputFile.path)]);
+    } else {
+      await Share.shareXFiles(
+        [XFile(outputFile.path)],
+        sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Overview

With current fix for onShare when it is on iPad, we were using RenderBox to send sharePositionOrigin, but in some cases (maybe when it is on android), this returns null and throws CastError exception. [link](https://sentry.io/organizations/galactic-galleries/issues/3906909336/?alert_rule_id=13166061&alert_timestamp=1675129368582&alert_type=email&environment=production&project=4504362837082112&referrer=alert_email)

So i have added null check before actually using it, (not sure we should add double check like platform - maybe redundant)

### From
```
    final RenderBox box = context.findRenderObject() as RenderBox;
    final outputFile = await imageTranscodeBloc.transcodeImageToJpg(task);
    await Share.shareXFiles(
      [XFile(outputFile.path)],
      sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
    );
```

### To
```
    final RenderBox? box = context.findRenderObject() as RenderBox?;
    final outputFile = await imageTranscodeBloc.transcodeImageToJpg(task);

    if (box == null) {
      await Share.shareXFiles([XFile(outputFile.path)]);
    } else {
      await Share.shareXFiles(
        [XFile(outputFile.path)],
        sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
      );
    }
```


